### PR TITLE
Added RequestInfo to ErrorDump that includes the route, protocol and …

### DIFF
--- a/src/main/scala/com/fullfacing/keycloak4s/models/ErrorDump.scala
+++ b/src/main/scala/com/fullfacing/keycloak4s/models/ErrorDump.scala
@@ -1,15 +1,21 @@
 package com.fullfacing.keycloak4s.models
 
+case class RequestInfo(path: String,
+                       protocol: String,
+                       body: Option[Any] = None)
+
 case class ErrorDump(code: Int,
                      body: String,
                      headers: Seq[(String, String)],
-                     rawBody: String,
-                     statusText: String) extends Throwable {
+                     statusText: String,
+                     requestInfo: RequestInfo) extends Throwable {
 
   override def toString: String = {
+    val requestBody = requestInfo.body.fold("")(b => s"\nRequest Body: ${b.toString}")
+
     s"""STTP CLIENT ERROR: $code $statusText
        |Headers: ${headers.toMap}
        |Body: $body
-       |Raw Body: $rawBody""".stripMargin
+       |Request Endpoint: ${requestInfo.protocol} ${requestInfo.path}""".stripMargin + requestBody
   }
 }


### PR DESCRIPTION
Added RequestInfo to ErrorDump that includes the route, protocol and body (if any) of the request.

Example of how the ErrorDump is now logged in the console:
```STTP CLIENT ERROR: 400 Bad Request
Headers: Map(Connection -> keep-alive, Content-Length -> 75, Cache-Control -> no-store, Content-Type -> application/json, Pragma -> no-cache, Date -> Wed, 03 Apr 2019 08:01:49 GMT)
Body: {"error":"unauthorized_client","error_description":"Invalid client secret"}
Request Endpoint: POST auth/realms/master/protocol/openid-connect/token
Request Body: Map(grant_type -> client_credentials, client_id -> admin-cli, client_secret -> 6808820a-b662-4480-b832-f2d024eb6e03)```