### PR TITLE
KeycloakClient rewrite with magnet pattern and return type definition constraint.

### DIFF
--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/Keycloak.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/Keycloak.scala
@@ -22,7 +22,7 @@ object Keycloak {
   def Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient[R, S]) = new Users[R, S](realm)
   def Roles[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient[R, S]) = new Roles[R, S](realm)
   def Groups[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient[R, S]) = new Groups[R, S](realm)
-  def RolesById[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient[R, S]) = new RolesById[R, S]
+  def RolesById[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) = new RolesById[R, S]
 
   def Clients[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) = new Clients[R, S]
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/KeycloakClient.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/KeycloakClient.scala
@@ -2,12 +2,12 @@ package com.fullfacing.keycloak4s.client
 
 import cats.effect.Concurrent
 import cats.implicits._
+import com.fullfacing.keycloak4s.client.implicits.{Anything, BodyMagnet}
 import com.fullfacing.keycloak4s.client.serialization.JsonFormats.default
-import com.fullfacing.keycloak4s.models.enums.ContentTypes
 import com.fullfacing.keycloak4s.models.{KeycloakAdminException, KeycloakError, KeycloakException, RequestInfo}
 import com.softwaremill.sttp.Uri.QueryFragment.KeyValue
 import com.softwaremill.sttp.json4s._
-import com.softwaremill.sttp.{Id, Multipart, Request, RequestT, SttpBackend, Uri, sttp}
+import com.softwaremill.sttp.{Id, RequestT, SttpBackend, Uri, sttp}
 import org.json4s.jackson.Serialization.read
 
 import scala.collection.immutable.Seq
@@ -18,6 +18,8 @@ import scala.util.control.NonFatal
 class KeycloakClient[F[+_] : Concurrent, -S](config: KeycloakConfig)(implicit client: SttpBackend[F, S]) extends TokenManager[F, S](config) {
 
   val realm: String = config.realm
+
+  private implicit def ma[A : Anything]: Manifest[A] = implicitly[Anything[A]].manifest
 
   /* URI Builder **/
   private[client] def createUri(path: Seq[String], query: Seq[KeyValue]) = Uri(
@@ -32,21 +34,14 @@ class KeycloakClient[F[+_] : Concurrent, -S](config: KeycloakConfig)(implicit cl
 
   /* HTTP Call Builders **/
 
-  private def setRequest[A](request: Request[String, Nothing], payload: A): RequestT[Id, String, Nothing] = payload match {
-    case m: Map[_, _] => request.contentType(ContentTypes.UrlEncoded).body(m)
-    case p: Multipart => request.contentType(ContentTypes.Multipart).body(p)
-    case _: Unit      => request
-    case j: AnyRef    => request.contentType(ContentTypes.Json).body(j)
-  }
-
   private def setResponse[A <: Any : Manifest](request: RequestT[Id, String, Nothing])(implicit tag: TypeTag[A])
   : F[Either[KeycloakAdminException, RequestT[Id, A, Nothing]]] = tag match {
-    case _ if tag == typeTag[Unit] => withAuth(request.mapResponse(_ => read[A]("null"))) //reading the string literal "null" is how you deserialize to a Unit with json4s
+    case _ if tag == typeTag[Unit] => withAuth(request.mapResponse(_ => read[A]("null"))) //reading the string literal "null" is how to deserialize to a Unit with json4s
     case _                         => withAuth(request.response(asJson[A]))
   }
 
-  private def call[A, B <: Any : Manifest](request: Request[String, Nothing], payload: A, requestInfo: RequestInfo): F[Either[KeycloakError, B]] = {
-    val resp = setResponse[B](setRequest(request, payload))
+  private def call[B <: Any : Manifest](request: RequestT[Id, String, Nothing], requestInfo: RequestInfo): F[Either[KeycloakError, B]] = {
+    val resp = setResponse[B](request)
 
     val response = F.flatMap(resp) {
       case Right(r) => F.map(r.send())(liftM(_, requestInfo))
@@ -59,23 +54,26 @@ class KeycloakClient[F[+_] : Concurrent, -S](config: KeycloakConfig)(implicit cl
   }
 
   /* REST Protocol Calls **/
-  def get[A <: Any : Manifest](path: Seq[String], query: Seq[KeyValue] = Seq.empty[KeyValue]): F[Either[KeycloakError, A]] = {
+  def get[A: Anything](path: Seq[String], query: Seq[KeyValue] = Seq.empty[KeyValue]): F[Either[KeycloakError, A]] = {
     val request = sttp.get(createUri(path, query))
-    call[Unit, A](request, (), buildRequestInfo(path, "GET", ()))
+    call[A](request, buildRequestInfo(path, "GET", ()))
   }
 
-  def put[A, B <: Any : Manifest](path: Seq[String], payload: A = (), query: Seq[KeyValue] = Seq.empty[KeyValue]): F[Either[KeycloakError, B]] = {
-    val request = sttp.put(createUri(path, query))
-    call[A, B](request, payload, buildRequestInfo(path, "PUT", payload))
+  def put[A: Anything](path: Seq[String], payload: BodyMagnet = (), query: Seq[KeyValue] = Seq.empty[KeyValue]): F[Either[KeycloakError, A]] = {
+    val request   = sttp.put(createUri(path, query))
+    val injected  = payload.apply(request)
+    call[A](injected, buildRequestInfo(path, "PUT", injected.body))
   }
 
-  def post[A, B <: Any : Manifest](path: Seq[String], payload: A = (), query: Seq[KeyValue] = Seq.empty[KeyValue]): F[Either[KeycloakError, B]] = {
-    val request = sttp.post(createUri(path, query))
-    call[A, B](request, payload, buildRequestInfo(path, "POST", payload))
+  def post[A: Anything](path: Seq[String], payload: BodyMagnet = (), query: Seq[KeyValue] = Seq.empty[KeyValue]): F[Either[KeycloakError, A]] = {
+    val request   = sttp.post(createUri(path, query))
+    val injected  = payload.apply(request)
+    call[A](payload.apply(injected), buildRequestInfo(path, "POST", injected.body))
   }
 
-  def delete[A, B <: Any : Manifest](path: Seq[String], payload: A = (), query: Seq[KeyValue] = Seq.empty[KeyValue]): F[Either[KeycloakError, B]] = {
-    val request = sttp.delete(createUri(path, query))
-    call[A, B](request, payload, buildRequestInfo(path, "DELETE", payload))
+  def delete[A: Anything](path: Seq[String], payload: BodyMagnet = (), query: Seq[KeyValue] = Seq.empty[KeyValue]): F[Either[KeycloakError, A]] = {
+    val request   = sttp.delete(createUri(path, query))
+    val injected  = payload.apply(request)
+    call[A](payload.apply(injected), buildRequestInfo(path, "DELETE", injected.body))
   }
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/TokenManager.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/TokenManager.scala
@@ -25,6 +25,7 @@ abstract class TokenManager[F[_] : Concurrent, -S](config: KeycloakConfig)(impli
       protocol  = protocol,
       body      = body match {
         case _: Unit  => None
+        case NoBody   => None
         case a        => Some(a)
       }
     )

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/implicits/Anything.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/implicits/Anything.scala
@@ -1,0 +1,20 @@
+package com.fullfacing.keycloak4s.client.implicits
+
+import scala.annotation.implicitAmbiguous
+import scala.reflect.Manifest
+
+/**
+ * Used to represent a generic type that cannot be a Nothing, and therefor must be specified. Carries a Manifest of the type.
+ * Based on code by Piotr Tarsa from contributors.scala-lang.org
+ *
+ * https://contributors.scala-lang.org/t/ability-to-force-the-caller-to-specify-a-type-parameter-for-a-polymorphic-method/2116/9
+ */
+class Anything[T <: Any](implicit val manifest: Manifest[T])
+
+object Anything {
+  implicit def something[T: Manifest]: Anything[T] = new Anything[T]()
+
+  @implicitAmbiguous("Generic return type must be specified.")
+  implicit def nothingA: Anything[Nothing] = new Anything[Nothing]()
+  implicit def nothingB: Anything[Nothing] = new Anything[Nothing]()
+}

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/implicits/BodyMagnet.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/client/implicits/BodyMagnet.scala
@@ -1,0 +1,33 @@
+package com.fullfacing.keycloak4s.client.implicits
+
+import com.fullfacing.keycloak4s.client.serialization.JsonFormats.default
+import com.fullfacing.keycloak4s.models.enums.ContentTypes
+import com.softwaremill.sttp.json4s._
+import com.softwaremill.sttp.{Id, Multipart, Request, RequestT}
+import org.json4s.jackson.Serialization
+
+sealed trait BodyMagnet {
+  def apply: Request[String, Nothing] => RequestT[Id, String, Nothing]
+}
+
+object BodyMagnet {
+  private implicit val serialization: Serialization.type = org.json4s.jackson.Serialization
+
+  type Result = Request[String, Nothing] => RequestT[Id, String, Nothing]
+
+  implicit def fromMap(m: Map[Any, Any]): BodyMagnet = new BodyMagnet {
+    def apply: Result = request => request.contentType(ContentTypes.UrlEncoded).body(m)
+  }
+
+  implicit def fromMultipart(mp: Multipart): BodyMagnet = new BodyMagnet {
+    def apply: Result = request => request.contentType(ContentTypes.Multipart).body(mp)
+  }
+
+  implicit def fromUnit(u: Unit): BodyMagnet = new BodyMagnet {
+    def apply: Result = request => request
+  }
+
+  implicit def fromAnyRef[A <: AnyRef](a: A): BodyMagnet = new BodyMagnet {
+    def apply: Result = request => request.contentType(ContentTypes.Json).body(a)
+  }
+}

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/AttackDetection.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/AttackDetection.scala
@@ -13,7 +13,7 @@ class AttackDetection[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    * @return
    */
   def clearAllLoginFailures(): R[Either[KeycloakError, Unit]] = {
-    client.delete(client.realm :: "attack-detection" :: "brute-force" :: "users" :: Nil)
+    client.delete[Unit](client.realm :: "attack-detection" :: "brute-force" :: "users" :: Nil)
   }
 
   /**
@@ -33,6 +33,6 @@ class AttackDetection[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    * @param userId  ID of the User.
    */
   def clearUserLoginFailure(userId: String): R[Either[KeycloakError, Unit]] = {
-    client.delete(client.realm :: "attack-detection" :: "brute-force" :: "users" :: userId :: Nil)
+    client.delete[Unit](client.realm :: "attack-detection" :: "brute-force" :: "users" :: userId :: Nil)
   }
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/AuthenticationManagement.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/AuthenticationManagement.scala
@@ -58,7 +58,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def updateAuthenticatorConfig(configId: String, request: AuthenticatorConfig): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "config", configId)
-    client.put[AuthenticatorConfig, Unit](path, request)
+    client.put[Unit](path, request)
   }
 
   /**
@@ -69,7 +69,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def deleteAuthenticatorConfig(configId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "config", configId)
-    client.delete[Unit, Unit](path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -80,7 +80,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def addNewAuthenticationExecution(request: AuthenticationExecution): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "executions")
-    client.post[AuthenticationExecution, Unit](path, request)
+    client.post[Unit](path, request)
   }
 
   /**
@@ -91,7 +91,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def getSingleExecution(executionId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "executions", executionId)
-    client.get(path)
+    client.get[Unit](path)
   }
 
   /**
@@ -102,7 +102,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def deleteExecution(executionId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "executions", executionId)
-    client.delete[Unit, Unit](path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -114,7 +114,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def updateExecutionConfig(executionId: String, request: AuthenticatorConfig): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "executions", executionId, "config")
-    client.post[AuthenticatorConfig, Unit](path, request)
+    client.post[Unit](path, request)
   }
 
   /**
@@ -125,7 +125,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def lowerExecutionPriority(executionId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "executions", executionId, "lower-priority")
-    client.post[Unit, Unit](path)
+    client.post[Unit](path)
   }
 
   /**
@@ -136,7 +136,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def raiseExecutionPriority(executionId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "executions", executionId, "raise-priority")
-    client.post[Unit, Unit](path)
+    client.post[Unit](path)
   }
 
   /**
@@ -158,7 +158,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def copyAuthenticationFlow(flowAlias: String, newName: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "flows", flowAlias, "copy")
-    client.post[Map[String, String], Unit](path, Map("newName" -> newName))
+    client.post[Unit](path, Map("newName" -> newName))
   }
 
   /**
@@ -169,7 +169,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def getFlowAuthenticationExecutions(flowAlias: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "flows", flowAlias, "executions")
-    client.get(path)
+    client.get[Unit](path)
   }
 
   /**
@@ -181,7 +181,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def updateFlowAuthenticationExecutions(flowAlias: String, request: AuthenticationExecutionInfo): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "flows", flowAlias, "executions")
-    client.put[AuthenticationExecutionInfo, Unit](path, request)
+    client.put[Unit](path, request)
   }
 
   /**
@@ -193,7 +193,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def addFlowAuthenticationExecution(flowAlias: String, provider: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "flows", flowAlias, "executions", "execution")
-    client.post[ProviderWrapper, Unit](path, ProviderWrapper(provider))
+    client.post[Unit](path, ProviderWrapper(provider))
   }
 
   /**
@@ -205,7 +205,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def addNewFlowWithNewExecution(flowAlias: String, request: NewAuthenticationFlow): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "flows", flowAlias, "executions", "flow")
-    client.post[NewAuthenticationFlow, Unit](path, request)
+    client.post[Unit](path, request)
   }
 
   /**
@@ -228,7 +228,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def updateAuthenticationFlow(flowId: String, flow: AuthenticationFlow): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "flows", flowId)
-    client.put[AuthenticationFlow, Unit](path, flow)
+    client.put[Unit](path, flow)
   }
 
   /**
@@ -239,7 +239,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def deleteAuthenticationFlow(flowId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "flows", flowId)
-    client.delete[Unit, Unit](path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -280,7 +280,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def registerRequiredAction(requiredAction: RequiredAction): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "register-required-action")
-    client.post[RequiredAction, Unit](path, requiredAction)
+    client.post[Unit](path, requiredAction)
   }
 
   /**
@@ -313,7 +313,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def updateRequiredAction(alias: String, request: RequiredActionProvider): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "register-actions", alias)
-    client.put[RequiredActionProvider, Unit](path, request)
+    client.put[Unit](path, request)
   }
 
   /**
@@ -324,7 +324,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def deleteRequiredAction(alias: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "register-actions", alias)
-    client.delete[Unit, Unit](path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -335,7 +335,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def lowerRequiredActionPriority(alias: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "register-actions", alias, "lower-priority")
-    client.post[Unit, Unit](path)
+    client.post[Unit](path)
   }
 
   /**
@@ -346,7 +346,7 @@ class AuthenticationManagement[R[+_]: Concurrent, S](implicit client: KeycloakCl
    */
   def raiseRequiredActionPriority(alias: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "authentication", "register-actions", alias, "raise-priority")
-    client.post[Unit, Unit](path)
+    client.post[Unit](path)
   }
 
   /**

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Clients.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Clients.scala
@@ -5,7 +5,6 @@ import java.io.File
 import cats.effect.Concurrent
 import com.fullfacing.keycloak4s.client.KeycloakClient
 import com.fullfacing.keycloak4s.models._
-import com.softwaremill.sttp.Multipart
 
 import scala.collection.immutable.Seq
 
@@ -18,7 +17,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
    * @return
    */
   def createNewInitialAccessToken(config: ClientInitialAccessCreate): R[Either[KeycloakError, ClientInitialAccess]] = {
-    keycloakClient.post[ClientInitialAccessCreate, ClientInitialAccess](keycloakClient.realm :: "clients-initial-access" :: Nil, config)
+    keycloakClient.post[ClientInitialAccess](keycloakClient.realm :: "clients-initial-access" :: Nil, config)
   }
 
   /**
@@ -36,7 +35,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
     * @return
     */
   def deleteInitialAccessToken(tokenId: String): R[Either[KeycloakError, Unit]] = {
-    keycloakClient.delete(keycloakClient.realm :: "clients-initial-access" :: tokenId :: Nil)
+    keycloakClient.delete[Unit](keycloakClient.realm :: "clients-initial-access" :: tokenId :: Nil)
   }
 
 
@@ -49,7 +48,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def createNewClient(client: Client): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients")
-      keycloakClient.post[Client, Unit](path, client)
+      keycloakClient.post[Unit](path, client)
     }
 
     /**
@@ -85,7 +84,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def updateClient(clientId: String, c: Client): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId)
-      keycloakClient.put[Client, Unit](path, c)
+      keycloakClient.put[Unit](path, c)
     }
 
     /**
@@ -96,7 +95,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def deleteClient(clientId: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId)
-      keycloakClient.delete(path)
+      keycloakClient.delete[Unit](path)
     }
 
     /**
@@ -107,7 +106,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def generateClientSecret(clientId: String): R[Either[KeycloakError, Credential]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "client-secret")
-      keycloakClient.post[Unit, Credential](path)
+      keycloakClient.post[Credential](path)
     }
 
     /**
@@ -142,7 +141,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def updateClientScope(clientScopeId: String, clientId: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "default-client-scopes", clientScopeId)
-      keycloakClient.put(path)
+      keycloakClient.put[Unit](path)
     }
 
     /**
@@ -154,7 +153,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def deleteClientScope(clientScopeId: String, clientId: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "default-client-scopes", clientScopeId)
-      keycloakClient.delete(path)
+      keycloakClient.delete[Unit](path)
     }
 
     /**
@@ -186,7 +185,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
       val query = createQuery(("scope", scope))
 
       val path = Seq(keycloakClient.realm, "clients", clientId, "evaluate-scopes", "protocol-mappers")
-      keycloakClient.get(path, query = query)
+      keycloakClient.get[Seq[ClientScopeEvaluateResourceProtocolMapperEvaluation]](path, query = query)
     }
 
     /**
@@ -202,7 +201,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
       val query = createQuery(("scope", scope))
 
       val path = Seq(keycloakClient.realm, "clients", clientId, "evaluate-scopes", "scope-mappings", roleContainerId, "granted")
-      keycloakClient.get(path, query = query)
+      keycloakClient.get[Seq[Role]](path, query = query)
     }
 
     /**
@@ -217,7 +216,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
       val query = createQuery(("scope", scope))
 
       val path = Seq(keycloakClient.realm, "clients", clientId, "evaluate-scopes", "scope-mappings", roleContainerId, "not-granted")
-      keycloakClient.get(path, query = query)
+      keycloakClient.get[Seq[Role]](path, query = query)
     }
 
     /**
@@ -229,7 +228,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def getClientInstallationProvider(clientId: String, providerId: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "installation", "providers", providerId)
-      keycloakClient.get(path)
+      keycloakClient.get[Unit](path)
     }
 
     /**
@@ -252,7 +251,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def updateClientAuthorizationPermissions(clientId: String, permission: ManagementPermission): R[Either[KeycloakError, ManagementPermission]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "management", "permissions")
-      keycloakClient.put[ManagementPermission, ManagementPermission](path, permission)
+      keycloakClient.put[ManagementPermission](path, permission)
     }
 
     /**
@@ -265,7 +264,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def registerClusterNode(clientId: String, node: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "nodes")
-      keycloakClient.post[Map[String, String], Unit](path, Map("node" -> node)) //If Sttp throws an error, then the node String needs to be wraooed in a case class instead of a Map.
+      keycloakClient.post[Unit](path, Map("node" -> node)) //If Sttp throws an error, then the node String needs to be wraooed in a case class instead of a Map.
     }
 
     /**
@@ -276,7 +275,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def unregisterClusterNode(clientId: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "nodes")
-      keycloakClient.delete(path)
+      keycloakClient.delete[Unit](path)
     }
 
     /**
@@ -331,7 +330,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def updateOptionalClientScope(clientScopeId: String, clientId: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "optional-client-scopes", clientScopeId)
-      keycloakClient.put(path)
+      keycloakClient.put[Unit](path)
     }
 
     /**
@@ -343,7 +342,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def deleteOptionalClientScope(clientScopeId: String, clientId: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "optional-client-scopes", clientScopeId)
-      keycloakClient.delete(path)
+      keycloakClient.delete[Unit](path)
     }
 
     /**
@@ -355,7 +354,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def pushRevocationPolicy(clientId: String): R[Either[KeycloakError, GlobalRequestResult]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "push-revocation")
-      keycloakClient.post[Unit, GlobalRequestResult](path)
+      keycloakClient.post[GlobalRequestResult](path)
     }
 
     /**
@@ -366,7 +365,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def generateRegistrationAccessToken(clientId: String): R[Either[KeycloakError, Client]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "registration-access-token")
-      keycloakClient.post[Unit, Client](path)
+      keycloakClient.post[Client](path)
     }
 
     /**
@@ -443,7 +442,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def addRolesToGroup(clientId: String, groupId: String, roles: Seq[Role]): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "groups", groupId, "role-mappings", "clients", clientId)
-      keycloakClient.post(path, roles)
+      keycloakClient.post[Unit](path, roles)
     }
 
     /**
@@ -455,7 +454,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def getGroupRoleMappings(clientId: String, groupId: String): R[Either[KeycloakError, Seq[Role]]] = {
       val path = Seq(keycloakClient.realm, "groups", groupId, "role-mappings", "clients", clientId)
-      keycloakClient.get(path)
+      keycloakClient.get[Seq[Role]](path)
     }
 
     /**
@@ -468,7 +467,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def deleteGroupRoles(clientId: String, groupId: String, roles: Seq[Role]): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "groups", groupId, "role-mappings", "clients", clientId)
-      keycloakClient.delete(path, roles)
+      keycloakClient.delete[Unit](path, roles)
     }
 
     /**
@@ -506,7 +505,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def addRolesToUser(clientId: String, userId: String, roles: Seq[Role]): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "users", userId, "role-mappings", "clients", clientId)
-      keycloakClient.post(path, roles)
+      keycloakClient.post[Unit](path, roles)
     }
 
     /**
@@ -531,7 +530,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def deleteUserRoles(clientId: String, groupId: String, roles: Seq[Role]): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "groups", groupId, "role-mappings", "clients", clientId)
-      keycloakClient.delete(path, roles)
+      keycloakClient.delete[Unit](path, roles)
     }
 
     /**
@@ -581,7 +580,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def getKeystoreFile(attribute: String, clientId: String, config: KeyStoreConfig): R[Either[KeycloakError, File]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "certificates", attribute, "download")
-      keycloakClient.post[KeyStoreConfig, File](path, config)
+      keycloakClient.post[File](path, config)
     }
 
     /**
@@ -593,7 +592,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def generateNewCertificate(attribute: String, clientId: String): R[Either[KeycloakError, Certificate]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "certificates", attribute, "generate")
-      keycloakClient.post[Unit, Certificate](path)
+      keycloakClient.post[Certificate](path)
     }
 
     /**
@@ -606,7 +605,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def generateAndDownloadNewCertificate(attribute: String, clientId: String, config: KeyStoreConfig): R[Either[KeycloakError, File]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "certificates", attribute, "generate-and-download")
-      keycloakClient.post[KeyStoreConfig, File](path, config)
+      keycloakClient.post[File](path, config)
     }
 
     /**
@@ -620,7 +619,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
     def uploadCertificateWithPrivateKey(attribute: String, clientId: String, file: File): R[Either[KeycloakError, Certificate]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "certificates", attribute, "upload")
       val multipart = createMultipart(file)
-      keycloakClient.post[Multipart, Certificate](path, multipart)
+      keycloakClient.post[Certificate](path, multipart)
     }
 
     /**
@@ -634,7 +633,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
     def uploadCertificateWithoutPrivateKey(attribute: String, clientId: String, file: File): R[Either[KeycloakError, Certificate]] = {
       val path = Seq(keycloakClient.realm, "clients", clientId, "certificates", attribute, "upload-certificate")
       val multipart = createMultipart(file)
-      keycloakClient.post[Multipart, Certificate](path, multipart)
+      keycloakClient.post[Certificate](path, multipart)
     }
 
     /**
@@ -646,7 +645,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def createNewClientScope(clientScope: ClientScope): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "client-scopes")
-      keycloakClient.post[ClientScope, Unit](path, clientScope)
+      keycloakClient.post[Unit](path, clientScope)
     }
 
     /**
@@ -658,7 +657,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def updateClientScope(scopeId: String, clientScope: ClientScope): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "client-scopes", scopeId)
-      keycloakClient.put[ClientScope, Unit](path, clientScope)
+      keycloakClient.put[Unit](path, clientScope)
     }
 
     /**
@@ -669,7 +668,7 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def deleteClientScope(scopeId: String): R[Either[KeycloakError, Unit]] = {
       val path = Seq(keycloakClient.realm, "client-scopes", scopeId)
-      keycloakClient.delete(path)
+      keycloakClient.delete[Unit](path)
     }
 
     /**
@@ -688,6 +687,6 @@ class Clients[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R, S
      */
     def getClientScope(scopeId: String): R[Either[KeycloakError, ClientScope]] = {
       val path = Seq(keycloakClient.realm, "client-scopes", scopeId)
-      keycloakClient.get(path)
+      keycloakClient.get[ClientScope](path)
     }
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Components.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Components.scala
@@ -15,7 +15,7 @@ class Components[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    * @return
    */
   def createComponent(component: Component): R[Either[KeycloakError, Unit]] = {
-    client.post[Component, Unit](client.realm :: "components" :: Nil, component)
+    client.post[Unit](client.realm :: "components" :: Nil, component)
   }
 
   /**
@@ -43,7 +43,7 @@ class Components[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    * @return
    */
   def updateComponent(componentId: String, component: Component): R[Either[KeycloakError, Component]] = {
-    client.put[Component, Component](client.realm :: "components" :: componentId :: Nil, component)
+    client.put[Component](client.realm :: "components" :: componentId :: Nil, component)
   }
 
   /**
@@ -53,7 +53,7 @@ class Components[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    * @return
    */
   def deleteComponent(componentId: String): R[Either[KeycloakError, Unit]] = {
-    client.delete(client.realm :: "components" :: componentId :: Nil)
+    client.delete[Unit](client.realm :: "components" :: componentId :: Nil)
   }
 
   /**

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Groups.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Groups.scala
@@ -15,12 +15,12 @@ class Groups[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClien
   // ------------------------------------------------------------------------------------------------------ //
   def create(group: Group.Create): R[Either[KeycloakError, Group]] = {
     val path = Seq(realm, "groups")
-    client.post[Group.Create, Group](path, group)
+    client.post[Group](path, group)
   }
 
   def createSubGroup(groupId: UUID, group: Group.Create): R[Either[KeycloakError, Group]] = {
     val path = Seq(realm, "groups", groupId.toString, "children")
-    client.post[Group.Create, Group](path, group)
+    client.post[Group](path, group)
   }
 
   def fetch(first: Option[Int] = None, max: Option[Int] = None, search: Option[String] = None): R[Either[KeycloakError, Seq[Group]]] = {
@@ -36,12 +36,12 @@ class Groups[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClien
 
   def update(groupId: UUID, group: Group): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, "groups", groupId.toString)
-    client.put[Group, Unit](path, group)
+    client.put[Unit](path, group)
   }
 
   def delete(groupId: UUID): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, "groups", groupId.toString)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   def count(search: Option[String] = None, top: Boolean = false): R[Either[KeycloakError, Count]] = {
@@ -61,12 +61,12 @@ class Groups[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClien
   
   def addUserToGroup(userId: UUID, groupId: UUID): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, "users", userId.toString, "groups", groupId.toString)
-    client.put(path)
+    client.put[Unit](path)
   }
 
   def removeUserFromGroup(userId: UUID, groupId: UUID): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, "users", userId.toString, "groups", groupId.toString)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   // ------------------------------------------------------------------------------------------------------- //
@@ -94,12 +94,12 @@ class Groups[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClien
 
   def addRealmRoles(id: UUID, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, "groups", id.toString, "role-mappings", "realm")
-    client.post[List[Role], Unit](path, roles)
+    client.post[Unit](path, roles)
   }
 
   def removeRealmRoles(id: UUID, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, "groups", id.toString, "role-mappings", "realm")
-    client.delete[List[Role], Unit](path, roles)
+    client.delete[Unit](path, roles)
   }
 
   // ------------------------------------------------------------------------------------------------------------- //
@@ -112,6 +112,6 @@ class Groups[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClien
   
   def updateManagementPermissions(groupId: UUID, permissions: ManagementPermission): R[Either[KeycloakError, ManagementPermission]] = {
     val path = Seq(realm, "groups", groupId.toString, "management", "permissions")
-    client.put[ManagementPermission, ManagementPermission](path, permissions)
+    client.put[ManagementPermission](path, permissions)
   }
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/IdentityProviders.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/IdentityProviders.scala
@@ -5,7 +5,6 @@ import java.io.File
 import cats.effect.Concurrent
 import com.fullfacing.keycloak4s.client.KeycloakClient
 import com.fullfacing.keycloak4s.models._
-import com.softwaremill.sttp.Multipart
 
 import scala.collection.immutable.Seq
 
@@ -20,7 +19,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
   def importIdentityProvider(config: File): R[Either[KeycloakError, Map[String, String]]] = {
     val path = Seq(client.realm, "identity-provider", "import-config")
     val multipart = createMultipart(config)
-    client.post[Multipart, Map[String, String]](path, multipart)
+    client.post[Map[String, String]](path, multipart)
   }
 
   /**
@@ -31,7 +30,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
    */
   def createIdentityProvider(identityProvider: IdentityProvider): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "identity-provider", "instances")
-    client.post[IdentityProvider, Unit](path, identityProvider)
+    client.post[Unit](path, identityProvider)
   }
 
   /**
@@ -61,7 +60,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
    */
   def updateIdentityProvider(alias: String, identityProvider: IdentityProvider): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "identity-provider", "instances", alias)
-    client.put[IdentityProvider, Unit](path, identityProvider)
+    client.put[Unit](path, identityProvider)
   }
 
   /**
@@ -72,7 +71,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
    */
   def deleteIdentityProvider(alias: String): R[Either[KeycloakError, IdentityProvider]] = {
     val path = Seq(client.realm, "identity-provider", "instances", alias)
-    client.delete[Unit, IdentityProvider](path)
+    client.delete[IdentityProvider](path)
   }
 
   /**
@@ -86,7 +85,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
     val query = createQuery(("format", format))
 
     val path = Seq(client.realm, "identity-provider", "instances", alias, "export")
-    client.get(path, query = query)
+    client.get[Unit](path, query = query)
   }
 
   /**
@@ -109,7 +108,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
    */
   def updateManagementPermissions(alias: String, permissions: ManagementPermission): R[Either[KeycloakError, ManagementPermission]] = {
     val path = Seq(client.realm, "identity-provider", "instances", alias, "management", "permissions")
-    client.put[ManagementPermission, ManagementPermission](path, permissions)
+    client.put[ManagementPermission](path, permissions)
   }
 
   /**
@@ -132,7 +131,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
    */
   def addMapperTypes(alias: String, mapper: IdentityProviderMapper): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "identity-provider", "instances", alias, "mapper")
-    client.post[IdentityProviderMapper, Unit](path, mapper)
+    client.post[Unit](path, mapper)
   }
 
   /**
@@ -168,7 +167,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
    */
   def updateMapper(alias: String, mapperId: String, mapper: IdentityProviderMapper): R[Either[KeycloakError, IdentityProviderMapper]] = {
     val path = Seq(client.realm, "identity-provider", "instances", alias, "mappers", mapperId)
-    client.put[IdentityProviderMapper, IdentityProviderMapper](path, mapper)
+    client.put[IdentityProviderMapper](path, mapper)
   }
 
   /**
@@ -180,7 +179,7 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
    */
   def deleteMapper(alias: String, mapperId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "identity-provider", "instances", alias, "mappers", mapperId)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -191,6 +190,6 @@ class IdentityProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient[R,
    */
   def getIdentityProviders(providerId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "identity-provider", "providers", providerId)
-    client.get(path)
+    client.get[Unit](path)
   }
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/ProtocolMappers.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/ProtocolMappers.scala
@@ -17,7 +17,7 @@ class ProtocolMappers[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    */
   def createMulitpleMappersForScope(scopeId: String, mapper: Seq[ProtocolMapper]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "client-scopes", scopeId, "protocol-mappers", "add-models")
-    client.post[Seq[ProtocolMapper], Unit](path, mapper)
+    client.post[Unit](path, mapper)
   }
 
   /**
@@ -29,7 +29,7 @@ class ProtocolMappers[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    */
   def createMapperForScope(scopeId: String, mapper: ProtocolMapper): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "client-scopes", scopeId, "protocol-mappers", "models")
-    client.post[ProtocolMapper, Unit](path, mapper)
+    client.post[Unit](path, mapper)
   }
 
   /**
@@ -65,7 +65,7 @@ class ProtocolMappers[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    */
   def updateMapperForScope(scopeId: String, mapperId: String, mapper: ProtocolMapper): R[Either[KeycloakError, ProtocolMapper]] = {
     val path = Seq(client.realm, "client-scopes", scopeId, "protocol-mappers", "models", mapperId)
-    client.put[ProtocolMapper, ProtocolMapper](path, mapper)
+    client.put[ProtocolMapper](path, mapper)
   }
 
   /**
@@ -77,7 +77,7 @@ class ProtocolMappers[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    */
   def deleteMapperForScope(scopeId: String, mapperId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "client-scopes", scopeId, "protocol-mappers", "models", mapperId)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -101,7 +101,7 @@ class ProtocolMappers[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    */
   def createMulitpleMappersForClient(clientId: String, mapper: Seq[ProtocolMapper]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "client-scopes", clientId, "protocol-mappers", "add-models")
-    client.post[Seq[ProtocolMapper], Unit](path, mapper)
+    client.post[Unit](path, mapper)
   }
 
   /**
@@ -113,7 +113,7 @@ class ProtocolMappers[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    */
   def createMapperForClient(clientId: String, mapper: ProtocolMapper): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "client-scopes", clientId, "protocol-mappers", "models")
-    client.post[ProtocolMapper, Unit](path, mapper)
+    client.post[Unit](path, mapper)
   }
 
   /**
@@ -149,7 +149,7 @@ class ProtocolMappers[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    */
   def updateMapperForClient(clientId: String, mapperId: String, mapper: ProtocolMapper): R[Either[KeycloakError, ProtocolMapper]] = {
     val path = Seq(client.realm, "client-scopes", clientId, "protocol-mappers", "models", mapperId)
-    client.put[ProtocolMapper, ProtocolMapper](path, mapper)
+    client.put[ProtocolMapper](path, mapper)
   }
 
   /**
@@ -161,7 +161,7 @@ class ProtocolMappers[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S
    */
   def deleteMapperForClient(clientId: String, mapperId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "client-scopes", clientId, "protocol-mappers", "models", mapperId)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/RealmsAdmin.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/RealmsAdmin.scala
@@ -3,7 +3,6 @@ package com.fullfacing.keycloak4s.services
 import cats.effect.Concurrent
 import com.fullfacing.keycloak4s.client.KeycloakClient
 import com.fullfacing.keycloak4s.models._
-import com.softwaremill.sttp.Multipart
 
 import scala.collection.immutable.Seq
 
@@ -14,7 +13,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def importRealm(realm: RealmRepresentation): R[Either[KeycloakError, Unit]] = {
     val path = Seq.empty[String]
-    client.post[RealmRepresentation, Unit](path, realm)
+    client.post[Unit](path, realm)
   }
 
   /**
@@ -37,7 +36,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def updateTopLevelRepresentation(update: RealmRepresentation): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm)
-    client.put[RealmRepresentation, Unit](path, update)
+    client.put[Unit](path, update)
   }
 
   /**
@@ -45,7 +44,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def deleteRealm(): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -100,7 +99,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def deleteAdminEvents(): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "admin-events")
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -110,7 +109,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def clearKeysCache(): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "clear-keys-cache")
-    client.post(path)
+    client.post[Unit](path)
   }
 
   /**
@@ -120,7 +119,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def clearRealmCache(): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "clear-realm-cache")
-    client.post(path)
+    client.post[Unit](path)
   }
 
   /**
@@ -130,7 +129,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def clearUserCache(): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "clear-user-cache")
-    client.post(path)
+    client.post[Unit](path)
   }
 
   /**
@@ -141,7 +140,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def importClientViaDescription(description: String): R[Either[KeycloakError, Client]] = {
     val path = Seq(client.realm, "client-description-converter")
-    client.post[String, Client](path, description)
+    client.post[Client](path, description)
   }
 
   /**
@@ -174,7 +173,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def updateDefaultClientScope(scopeId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "default-default-client-scopes", scopeId)
-    client.put(path)
+    client.put[Unit](path)
   }
 
   /**
@@ -185,7 +184,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def deleteDefaultClientScope(scopeId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "default-default-client-scopes", scopeId)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -207,7 +206,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def updateGroupHierarchy(groupId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "default-groups", groupId)
-    client.put(path)
+    client.put[Unit](path)
   }
 
   /**
@@ -218,7 +217,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def deleteGroupHierarchy(groupId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "default-groups", groupId)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -237,7 +236,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def updateOptionalClientScope(scopeId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "default-Optional-client-scopes", scopeId)
-    client.put(path)
+    client.put[Unit](path)
   }
 
   /**
@@ -248,7 +247,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def deleteOptionalClientScope(scopeId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "default-Optional-client-scopes", scopeId)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -294,7 +293,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def deleteAllEvents(): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "events")
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -317,7 +316,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def updateEventsConfig(config: RealmEventsConfig): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "events", "config")
-    client.put(path, config)
+    client.put[Unit](path, config)
   }
 
   /**
@@ -338,7 +337,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def logoutAll(): R[Either[KeycloakError, GlobalRequestResult]] = {
     val path = Seq(client.realm, "logout-all")
-    client.post[Unit, GlobalRequestResult](path)
+    client.post[GlobalRequestResult](path)
   }
 
   /**
@@ -353,7 +352,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
     val path    = Seq(client.realm, "partial-export")
     val queries = createQuery(("exportClients", exportClients), ("exportGroupsAndRoles", exportGroupsAndRoles))
 
-    client.post[Unit, RealmRepresentation](path, query = queries)
+    client.post[RealmRepresentation](path, query = queries)
   }
 
   /**
@@ -364,7 +363,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def partialImport(rep: PartialImport): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "partialImport")
-    client.post[PartialImport, Unit](path, rep)
+    client.post[Unit](path, rep)
   }
 
   /**
@@ -374,7 +373,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def pushRevocation(): R[Either[KeycloakError, GlobalRequestResult]] = {
     val path = Seq(client.realm, "push-revocation")
-    client.post[Unit, GlobalRequestResult](path)
+    client.post[GlobalRequestResult](path)
   }
 
   /**
@@ -386,7 +385,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def removeUserSession(session: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "sessions", session)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   /**
@@ -423,7 +422,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
     //Documentation does not specify which content type this endpoint consumes, multipart/form-data and application/json are equally likely.
     //Therefor, in case the endpoint returns an error, it may be required to build a case class from the query parameters instead of a multipart.
     val mp = createMultipart(flattenOptionMap(queries))
-    client.post[Multipart, Unit](path, mp)
+    client.post[Unit](path, mp)
   }
 
   /**
@@ -434,7 +433,7 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def testSmtpConnection(config: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, "testSMTPConnection", config)
-    client.post(path)
+    client.post[Unit](path)
   }
 
   /**
@@ -453,6 +452,6 @@ class RealmsAdmin[R[+_]: Concurrent, S](implicit client: KeycloakClient[R, S]) {
    */
   def updateUsersManagementPermissions(ref: ManagementPermission): R[Either[KeycloakError, ManagementPermission]] = {
     val path = Seq(client.realm, "users-management-permissions")
-    client.put[ManagementPermission, ManagementPermission](path, ref)
+    client.put[ManagementPermission](path, ref)
   }
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Roles.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Roles.scala
@@ -18,12 +18,12 @@ class Roles[R[+_]: Concurrent, S](realm: String)(implicit keyCloakClient: Keyclo
   // ------------------------------------------------------------------------------------------------------------------- //
   def createClientRole(clientId: UUID, role: Role.Create): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, clients_path, clientId.toString, roles_path)
-    keyCloakClient.post[Role.Create, Unit](path, role.copy(clientRole = true))
+    keyCloakClient.post[Unit](path, role.copy(clientRole = true))
   }
 
   def createCompositeClientRoles(clientId: UUID, name: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, clients_path, clientId.toString, roles_path, name, "composites")
-    keyCloakClient.post[List[Role], Unit](path, roles)
+    keyCloakClient.post[Unit](path, roles)
   }
 
   def fetchClientRoles(clientId: UUID): R[Either[KeycloakError, List[Role]]] = {
@@ -43,17 +43,17 @@ class Roles[R[+_]: Concurrent, S](realm: String)(implicit keyCloakClient: Keyclo
 
   def updateClientRoleByName(clientId: UUID, name: String, role: Role): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, clients_path, clientId.toString, roles_path, name)
-    keyCloakClient.put[Role, Unit](path, role)
+    keyCloakClient.put[Unit](path, role)
   }
 
   def removeClientRoleByName(clientId: UUID, name: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, clients_path, clientId.toString, roles_path, name)
-    keyCloakClient.delete(path)
+    keyCloakClient.delete[Unit](path)
   }
 
   def removeClientCompositeRoles(clientId: UUID, name: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, clients_path, clientId.toString, roles_path, name, "composites")
-    keyCloakClient.delete[List[Role], Unit](path, roles)
+    keyCloakClient.delete[Unit](path, roles)
   }
 
   def fetchCompositesAppLevelRoles(clientId: UUID, name: String, client: String): R[Either[KeycloakError, List[Role]]] = {
@@ -83,7 +83,7 @@ class Roles[R[+_]: Concurrent, S](realm: String)(implicit keyCloakClient: Keyclo
   // ------------------------------------------------------------------------------------------------------------------ //
   def createRealmRole(role: Role.Create): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, roles_path)
-    keyCloakClient.post[Role.Create, Unit](path, role.copy(clientRole = false))
+    keyCloakClient.post[Unit](path, role.copy(clientRole = false))
   }
 
   def fetchRealmRoles(): R[Either[KeycloakError, List[Role]]] = {
@@ -98,17 +98,17 @@ class Roles[R[+_]: Concurrent, S](realm: String)(implicit keyCloakClient: Keyclo
 
   def updateRealmRoleByName(name: String, role: Role): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, roles_path, name)
-    keyCloakClient.put[Role, Unit](path, role)
+    keyCloakClient.put[Unit](path, role)
   }
 
   def removeRealmRoleByName(name: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, roles_path, name)
-    keyCloakClient.delete(path)
+    keyCloakClient.delete[Unit](path)
   }
 
   def createCompositeRealmRoles(name: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, roles_path, name, "composites")
-    keyCloakClient.post[List[Role], Unit](path, roles)
+    keyCloakClient.post[Unit](path, roles)
   }
 
   def fetchCompositeRealmRoles(name: String): R[Either[KeycloakError, List[Role]]] = {
@@ -118,7 +118,7 @@ class Roles[R[+_]: Concurrent, S](realm: String)(implicit keyCloakClient: Keyclo
 
   def removeCompositeRealmRoles(name: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, roles_path, name, "composites")
-    keyCloakClient.delete[List[Role], Unit](path, roles)
+    keyCloakClient.delete[Unit](path, roles)
   }
 
   def fetchUsersByname(name: String, first: Option[Int], max: Option[Int]): R[Either[KeycloakError, User]] = {

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/RolesById.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/RolesById.scala
@@ -32,7 +32,7 @@ class RolesById[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R,
    */
   def update(realm: String, roleId: String, role: Role): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, resource, roleId)
-    keycloakClient.put[Role, Unit](path, role)
+    keycloakClient.put[Unit](path, role)
   }
 
   /**
@@ -44,7 +44,7 @@ class RolesById[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R,
    */
   def delete(realm: String, roleId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, resource, roleId)
-    keycloakClient.delete(path)
+    keycloakClient.delete[Unit](path)
   }
 
   /**
@@ -57,7 +57,7 @@ class RolesById[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R,
    */
   def addSubRoles(realm: String, roleId: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, resource, roleId, "composites")
-    keycloakClient.post[List[Role], Unit](path, roles)
+    keycloakClient.post[Unit](path, roles)
   }
 
   /**
@@ -82,7 +82,7 @@ class RolesById[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R,
    */
   def removeSubRoles(realm: String, roleId: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, resource, roleId, "composites")
-    keycloakClient.delete[List[Role], Unit](path, roles)
+    keycloakClient.delete[Unit](path, roles)
   }
 
   /**
@@ -132,6 +132,6 @@ class RolesById[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClient[R,
    */
   def initialiseRoleAuthPermissions(realm: String, roleId: String, ref: ManagementPermission): R[Either[KeycloakError, ManagementPermission]] = {
     val path = Seq(realm, resource, roleId, "management", "permissions")
-    keycloakClient.put[ManagementPermission, ManagementPermission](path, ref)
+    keycloakClient.put[ManagementPermission](path, ref)
   }
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/ScopeMappings.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/ScopeMappings.scala
@@ -32,7 +32,7 @@ class ScopeMappings[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClien
    */
   def addClientRoles(id: String, client: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(keycloakClient.realm, `client-scopes`, id, `scope-mappings`, "clients", client)
-    keycloakClient.post[List[Role], Unit](path, roles)
+    keycloakClient.post[Unit](path, roles)
   }
 
   /**
@@ -56,7 +56,7 @@ class ScopeMappings[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClien
    */
   def removeClientRoles(id: String, client: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(keycloakClient.realm, `client-scopes`, id, `scope-mappings`, "clients", client)
-    keycloakClient.delete[List[Role], Unit](path, roles)
+    keycloakClient.delete[Unit](path, roles)
   }
 
   /**
@@ -94,7 +94,7 @@ class ScopeMappings[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClien
    */
   def addRealmRolesToClientScope(id: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(keycloakClient.realm, `client-scopes`, id, `scope-mappings`, "realm")
-    keycloakClient.post[List[Role], Unit](path, roles)
+    keycloakClient.post[Unit](path, roles)
   }
 
   /**
@@ -117,7 +117,7 @@ class ScopeMappings[R[+_]: Concurrent, S](implicit keycloakClient: KeycloakClien
    */
   def removeRealmRolesFromClientScope(id: String, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(keycloakClient.realm, `client-scopes`, id, `scope-mappings`, "realm")
-    keycloakClient.delete[List[Role], Unit](path, roles)
+    keycloakClient.delete[Unit](path, roles)
   }
 
   /**

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/UserStorageProviders.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/UserStorageProviders.scala
@@ -41,7 +41,7 @@ class UserStorageProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient
    */
   def removeImportedUsers(userStorageId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, user_storage, userStorageId, "remove-imported-users")
-    client.post(path)
+    client.post[Unit](path)
   }
 
   /**
@@ -55,7 +55,7 @@ class UserStorageProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient
   def syncUsers(userStorageId: String, action: Option[String]): R[Either[KeycloakError, Synchronization]] = {
     val path  = Seq(client.realm, user_storage, userStorageId, "sync")
     val query = createQuery(("action", action))
-    client.post[Unit, Synchronization](path, query = query)
+    client.post[Synchronization](path, query = query)
   }
 
   /**
@@ -66,7 +66,7 @@ class UserStorageProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient
    */
   def unlink(userStorageId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(client.realm, user_storage, userStorageId, "unlink-users")
-    client.post(path)
+    client.post[Unit](path)
   }
 
   /**
@@ -81,6 +81,6 @@ class UserStorageProviders[R[+_]: Concurrent, S](implicit client: KeycloakClient
   def syncMapperData(mapperId: String, userStorageId: String, direction: Option[String]): R[Either[KeycloakError, Synchronization]] = {
     val path  = Seq(client.realm, user_storage, userStorageId, "mappers", mapperId, "sync")
     val query = createQuery(("direction", direction))
-    client.post[Unit, Synchronization](path, query = query)
+    client.post[Synchronization](path, query = query)
   }
 }

--- a/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Users.scala
+++ b/keycloak4s/src/main/scala/com/fullfacing/keycloak4s/services/Users.scala
@@ -15,9 +15,9 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
   // ------------------------------------------------------------------------------------------------------ //
   // ------------------------------------------------ CRUD ------------------------------------------------ //
   // ------------------------------------------------------------------------------------------------------ //
-  def create(user: User.Create): R[Either[KeycloakError, User]] = {
+  def create(user: User.Create): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path)
-    client.post[User.Create, User](path, user)
+    client.post[Unit](path, user)
   }
 
   def fetch(briefRep: Option[Boolean] = None, username: Option[String] = None, email: Option[String] = None, first: Option[Int] = None,
@@ -45,12 +45,12 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
 
   def update(userId: UUID, user: User): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId.toString)
-    client.put(path, user)
+    client.put[Unit](path, user)
   }
 
   def delete(userId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   // -------------------------------------------------------------------------------------------------------- //
@@ -76,7 +76,7 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
   
   def revokeClientConsentForUser(userId: UUID, clientId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId.toString, "consents", clientId)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   // -------------------------------------------------------------------------------------------------------------------- //
@@ -84,7 +84,7 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
   // -------------------------------------------------------------------------------------------------------------------- //
   def createFederatedIdentity(userId: UUID, provider: String, rep: FederatedIdentity): R[Either[KeycloakError, Unit]] = { // Unknown Return Type
     val path = Seq(realm, users_path, userId.toString, "federated-identity", provider)
-    client.post[FederatedIdentity, Unit](path, rep)
+    client.post[Unit](path, rep)
   }
   
   def fetchFederatedIdentities(userId: UUID): R[Either[KeycloakError, List[FederatedIdentity]]] = {
@@ -94,7 +94,7 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
 
   def removeFederatedIdentityProvider(userId: UUID, provider: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId.toString, "federated-identity", provider)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   // -------------------------------------------------------------------------------------------------------- //
@@ -108,7 +108,7 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
   def sendVerificationEmail(userId: UUID, clientId: Option[String] = None, redirectUri: Option[String] = None): R[Either[KeycloakError, Unit]] = {
     val query = createQuery(("client_id", clientId), ("redirect_uri",redirectUri))
     val path = Seq(realm, users_path, userId.toString, "send-verify-email")
-    client.put(path, query = query)
+    client.put[Unit](path, query = query)
   }
 
   /**
@@ -122,7 +122,7 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
                        redirectUri: Option[String], actions: List[String]): R[Either[KeycloakError, Unit]] = {
     val query = createQuery(("client_id", clientId), ("lifespan", lifespan), ("redirect_uri", redirectUri))
     val path = Seq(realm, users_path, userId.toString, "execute-actions-email")
-    client.put[List[String], Unit](path, actions, query)
+    client.put[Unit](path, actions, query)
   }
 
 
@@ -138,12 +138,12 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
   
   def addToGroup(userId: UUID, groupId: UUID): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId.toString, "groups", groupId.toString)
-    client.put(path)
+    client.put[Unit](path)
   }
   
   def removeFromGroup(userId: UUID, groupId: UUID): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId.toString, "groups", groupId.toString)
-    client.delete(path)
+    client.delete[Unit](path)
   }
 
   // -------------------------------------------------------------------------------------------------------- //
@@ -161,12 +161,12 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
 
   def addRealmRoles(userId: UUID, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, "users", userId.toString, "role-mappings", "realm")
-    client.post[List[Role], Unit](path, roles)
+    client.post[Unit](path, roles)
   }
 
   def removeRealmRoles(userId: UUID, roles: List[Role]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, "users", userId.toString, "role-mappings", "realm")
-    client.delete[List[Role], Unit](path, roles)
+    client.delete[Unit](path, roles)
   }
 
   def fetchAvailableRealmRoles(userId: UUID): R[Either[KeycloakError, List[Role]]] = {
@@ -195,26 +195,26 @@ class Users[R[+_]: Concurrent, S](realm: String)(implicit client: KeycloakClient
   
   def removeTotp(realm: String, userId: String): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId, "remove-totp")
-    client.put(path)
+    client.put[Unit](path)
   }
   
   def resetPassword(userId: UUID, credential: Credential): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId.toString, "reset-password")
-    client.put(path, credential)
+    client.put[Unit](path, credential)
   }
   
   def disableUserCredentials(userId: UUID, credentialTypes: List[String]): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId.toString, "disable-credential-types")
-    client.put[List[String], Unit](path, credentialTypes)
+    client.put[Unit](path, credentialTypes)
   }
   
   def impersonate(userId: UUID): R[Either[KeycloakError, ImpersonationResponse]] = {
     val path = Seq(realm, users_path, userId.toString, "impersonation")
-    client.post[Unit, ImpersonationResponse](path)
+    client.post[ImpersonationResponse](path)
   }
   
   def logout(userId: UUID): R[Either[KeycloakError, Unit]] = {
     val path = Seq(realm, users_path, userId.toString, "logout")
-    client.post(path)
+    client.post[Unit](path)
   }
 }


### PR DESCRIPTION
Two important changes in this PR:
1) The request type for calls made through KeycloakClient are now determined through magnets, dropping one of the two parametric types from the GET/POST/PUT/DELETE functions.
2) A method was implemented to force the parametric return type to be specified for the above functions, else the compiler will throw an error. This will prevent runtime errors when the return type was mistakingly left out.

The second change is coded a bit unorthodoxly, when reviewing please place extra attention on the new `Anything` class I added and how it is used in KeycloakClient.