### PR TITLE
File read fix for attemptBuild in PolicyBuilders.scala

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.1] - 2019-09-05
+## [1.2.0] - 2019-09-05
 ### Fixed
 - Fixed a flaw in attemptBuild in PolicyBuilders.scala that could potentially throw a FileNotFoundException in certain environments.
+### Changed
+- Core functionality in the Akka-HTTP auth module has been split into a separate module to allow code reuse by any client adapter.
 
 ## [1.1.0] - 2019-08-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.2.0] - 2019-09-05
+### Added
+- ConfigWithoutAuth; a version of KeycloakConfig that does not contain admin authentication details.
 ### Fixed
 - Fixed a flaw in attemptBuild in PolicyBuilders.scala that could potentially throw a FileNotFoundException in certain environments.
 ### Changed
 - Core functionality in the Akka-HTTP auth module has been split into a separate module to allow code reuse by any client adapter.
+- Transformed KeycloakConfig into a trait, with ConfigWithAuth and ConfigWithoutAuth as subtypes.
 
 ## [1.1.0] - 2019-08-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2019-09-05
+### Fixed
+- Fixed a flaw in attemptBuild in PolicyBuilders.scala that could potentially throw a FileNotFoundException in certain environments.
+
 ## [1.1.0] - 2019-08-27
 ### Added
 - KeycloakConfig.Auth split into two subtypes, Secret and Password, to additionally support a password grant type.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.fullfacing/keycloak4s-core_2.12.svg)](https://search.maven.org/search?q=a:keycloak4s-core_2.12)
 
 **A Scala-based middleware API for
-[Keycloak](https://www.keycloak.org/)**
-*Based on version 6.0.1*
+[Keycloak](https://www.keycloak.org/)**<br/>
+*Supports version 7.0.0*
 
 keycloak4s is an opinionated Scala-built API that serves as a bridge between any Scala project and a Keycloak server. It allows access to the server's [Admin API](https://www.keycloak.org/docs-api/6.0/rest-api/index.html), and provides adapters that validates Keycloak's bearer tokens. It authorizes requests via a JSON config file inspired by their [policy enforcement configuration][Policy-Configuration].
 
@@ -31,10 +31,10 @@ The project is split into the following modules, each as a separate dependency:
 ## Installation
 
 Each module can be pulled into a project separately using the following SBT dependencies:
-* keycloak4s-core:              `"com.fullfacing" %% "keycloak4s-core" % "1.1.0"`
-* keycloak4s-admin:             `"com.fullfacing" %% "keycloak4s-admin" % "1.1.0"`
-* keycloak4s-admin-monix:       `"com.fullfacing" %% "keycloak4s-admin-monix" % "1.1.0"`
-* keycloak4s-auth-akka-http:    `"com.fullfacing" %% "keycloak4s-auth-akka-http" % "1.1.0"`
+* keycloak4s-core:              `"com.fullfacing" %% "keycloak4s-core" % "1.2.0"`
+* keycloak4s-admin:             `"com.fullfacing" %% "keycloak4s-admin" % "1.2.0"`
+* keycloak4s-admin-monix:       `"com.fullfacing" %% "keycloak4s-admin-monix" % "1.2.0"`
+* keycloak4s-auth-akka-http:    `"com.fullfacing" %% "keycloak4s-auth-akka-http" % "1.2.0"`
 
 The core module is a dependency for all other modules, and is automatically pulled in when using any other module.
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import xerial.sbt.Sonatype.GitHubHosting
 
 lazy val global = {
   Seq(
-    version       := "1.1.1",
+    version       := "1.2.0",
     scalaVersion  := "2.12.8",
     organization  := "com.fullfacing",
     scalacOptions ++= scalacOpts,

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import xerial.sbt.Sonatype.GitHubHosting
 
 lazy val global = {
   Seq(
-    version       := "1.1.0",
+    version       := "1.1.1",
     scalaVersion  := "2.12.8",
     organization  := "com.fullfacing",
     scalacOptions ++= scalacOpts,

--- a/keycloak4s-admin-monix/src/main/scala/com/fullfacing/keycloak4s/admin/monix/client/KeycloakClient.scala
+++ b/keycloak4s-admin-monix/src/main/scala/com/fullfacing/keycloak4s/admin/monix/client/KeycloakClient.scala
@@ -12,7 +12,7 @@ import monix.reactive.Observable
 import scala.collection.immutable.Seq
 import scala.reflect._
 
-class KeycloakClient[T](config: KeycloakConfig)(implicit client: SttpBackend[Task, Observable[T]]) extends KeycloakClientA[Task, Observable[T]](config) {
+class KeycloakClient[T](config: ConfigWithAuth)(implicit client: SttpBackend[Task, Observable[T]]) extends KeycloakClientA[Task, Observable[T]](config) {
 
   /**
    * Used for calls that return a sequence of items, this sequentially makes calls to retrieve and process

--- a/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/KeycloakClient.scala
+++ b/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/KeycloakClient.scala
@@ -19,7 +19,7 @@ import scala.reflect._
 import scala.reflect.runtime.universe.{TypeTag, typeOf}
 import scala.util.control.NonFatal
 
-class KeycloakClient[F[+_] : Concurrent, -S](config: KeycloakConfig)(implicit client: SttpBackend[F, S]) extends TokenManager[F, S](config) {
+class KeycloakClient[F[+_] : Concurrent, -S](config: ConfigWithAuth)(implicit client: SttpBackend[F, S]) extends TokenManager[F, S](config) {
 
   val realm: String = config.realm
 

--- a/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/TokenManager.scala
+++ b/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/TokenManager.scala
@@ -11,12 +11,12 @@ import com.fullfacing.keycloak4s.admin.client.TokenManager.{Token, TokenResponse
 import com.fullfacing.keycloak4s.admin.handles.Logging
 import com.fullfacing.keycloak4s.admin.handles.Logging.handleLogging
 import com.fullfacing.keycloak4s.core.serialization.JsonFormats.default
-import com.fullfacing.keycloak4s.core.models.{KeycloakConfig, KeycloakSttpException, RequestInfo}
+import com.fullfacing.keycloak4s.core.models.{KeycloakConfig, ConfigWithAuth, KeycloakSttpException, RequestInfo}
 import com.softwaremill.sttp.json4s.asJson
 import com.softwaremill.sttp.{SttpBackend, _}
 import org.json4s.jackson.Serialization
 
-abstract class TokenManager[F[_] : Concurrent, -S](config: KeycloakConfig)(implicit client: SttpBackend[F, S]) {
+abstract class TokenManager[F[_] : Concurrent, -S](config: ConfigWithAuth)(implicit client: SttpBackend[F, S]) {
 
   protected implicit val serialization: Serialization.type = org.json4s.jackson.Serialization
 
@@ -52,12 +52,12 @@ abstract class TokenManager[F[_] : Concurrent, -S](config: KeycloakConfig)(impli
     uri"${config.scheme}://${config.host}:${config.port}/auth/realms/${config.authn.realm}/protocol/openid-connect/token"
 
   private val password = config.authn match {
-    case KeycloakConfig.Password(_, clientId, username, password) =>
+    case KeycloakConfig.Password(_, clientId, username, pass) =>
       Map(
         "grant_type"    -> "password",
         "client_id"     -> clientId,
         "username"      -> username,
-        "password"      -> password
+        "password"      -> pass
       )
     case KeycloakConfig.Secret(_, clientId, clientSecret) =>
       Map(

--- a/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/PolicyBuilders.scala
+++ b/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/PolicyBuilders.scala
@@ -12,15 +12,7 @@ object PolicyBuilders {
    * Throws an Exception in case of failure.
    */
   private def attemptBuild(filename: String): BufferedSource = {
-    val url = getClass.getResource(s"/$filename")
-
-    if (url == null) {
-      throw Exceptions.CONFIG_NOT_FOUND(filename)
-    } else try {
-      Source.fromFile(url.getPath)
-    } catch {
-      case th: Throwable => Logging.configSetupError(); throw th
-    }
+    Source.fromResource(filename)
   }
 
   /**

--- a/keycloak4s-core/src/main/scala/com/fullfacing/keycloak4s/core/models/KeycloakConfig.scala
+++ b/keycloak4s-core/src/main/scala/com/fullfacing/keycloak4s/core/models/KeycloakConfig.scala
@@ -1,6 +1,6 @@
 package com.fullfacing.keycloak4s.core.models
 
-trait KeycloakConfig {
+sealed trait KeycloakConfig {
   val scheme: String
   val host: String
   val port: Int

--- a/keycloak4s-core/src/main/scala/com/fullfacing/keycloak4s/core/models/KeycloakConfig.scala
+++ b/keycloak4s-core/src/main/scala/com/fullfacing/keycloak4s/core/models/KeycloakConfig.scala
@@ -1,11 +1,22 @@
 package com.fullfacing.keycloak4s.core.models
 
-final case class KeycloakConfig(scheme: String,
+trait KeycloakConfig {
+  val scheme: String
+  val host: String
+  val port: Int
+  val realm: String
+}
+
+final case class ConfigWithAuth(scheme: String,
                                 host: String,
                                 port: Int,
                                 realm: String,
-                                authn: KeycloakConfig.Auth)
+                                authn: KeycloakConfig.Auth) extends KeycloakConfig
 
+final case class ConfigWithoutAuth(scheme: String,
+                                   host: String,
+                                   port: Int,
+                                   realm: String) extends KeycloakConfig
 
 object KeycloakConfig {
 

--- a/keycloak4s-playground/src/main/scala/com/fullfacing/transport/Main.scala
+++ b/keycloak4s-playground/src/main/scala/com/fullfacing/transport/Main.scala
@@ -6,7 +6,7 @@ import cats.effect.ExitCode
 import com.fullfacing.backend.AkkaMonixHttpBackend
 import com.fullfacing.keycloak4s.admin.client.{Keycloak, KeycloakClient}
 import com.fullfacing.keycloak4s.admin.monix.client.{Keycloak => KeycloakM, KeycloakClient => KeycloakClientM}
-import com.fullfacing.keycloak4s.core.models.KeycloakConfig
+import com.fullfacing.keycloak4s.core.models.{ConfigWithAuth, KeycloakConfig}
 import com.fullfacing.keycloak4s.core.serialization.JsonFormats.default
 import com.fullfacing.transport.backends.AkkaHttpBackendL
 import com.fullfacing.transport.handles.Akka
@@ -31,7 +31,7 @@ object Main extends TaskApp {
   val adminSecret: String = "???" //Secret of adminClient.
 
   val authConfig  = KeycloakConfig.Secret(adminRealm, adminClient, adminSecret)
-  val config      = KeycloakConfig("http", host, port, targetRealm, authConfig)
+  val config      = ConfigWithAuth("http", host, port, targetRealm, authConfig)
 
   def run(args: List[String]): Task[ExitCode] = Akka.connect().flatMap { _ =>
 

--- a/keycloak4s-playground/src/test/scala/ValidationTests.scala
+++ b/keycloak4s-playground/src/test/scala/ValidationTests.scala
@@ -6,7 +6,7 @@ import cats.data.Validated.{invalidNel, valid}
 import cats.implicits._
 import com.fullfacing.keycloak4s.auth.core.validation.{ClaimValidators, TokenValidator}
 import com.fullfacing.keycloak4s.core.Exceptions
-import com.fullfacing.keycloak4s.core.models.KeycloakConfig
+import com.fullfacing.keycloak4s.core.models.ConfigWithoutAuth
 import com.nimbusds.jose.JWSSigner
 import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jose.jwk.RSAKey
@@ -21,8 +21,7 @@ class ValidationTests extends FlatSpec with Matchers with PrivateMethodTester wi
   val port    = 8080
   val realm   = "test"
 
-  val authConfig  = KeycloakConfig.Secret("", "", "")
-  val config      = KeycloakConfig(scheme, host, port, realm, authConfig)
+  val config      = ConfigWithoutAuth(scheme, host, port, realm)
 
   val validator: TokenValidator = TokenValidator.Static(TestData.jwkSet, config)
   val validatorUri = s"$scheme://$host:$port/auth/realms/$realm"

--- a/keycloak4s-playground/src/test/scala/suites/AttackDetectionTests.scala
+++ b/keycloak4s-playground/src/test/scala/suites/AttackDetectionTests.scala
@@ -16,7 +16,7 @@ import utils.{Errors, IntegrationSpec}
 @DoNotDiscover
 class AttackDetectionTests extends IntegrationSpec {
 
-  private val adKeycloakConfig  = KeycloakConfig("http", "127.0.0.1", 8080, "AttackRealm", authConfig)
+  private val adKeycloakConfig  = ConfigWithAuth("http", "127.0.0.1", 8080, "AttackRealm", authConfig)
   private val adClient: KeycloakClient[T] = new KeycloakClient(adKeycloakConfig)
 
   override val clientService: Clients[T] = Keycloak.Clients[ByteString](adClient)

--- a/keycloak4s-playground/src/test/scala/utils/AuthTestData.scala
+++ b/keycloak4s-playground/src/test/scala/utils/AuthTestData.scala
@@ -2,7 +2,7 @@ package utils
 
 import com.fullfacing.keycloak4s.auth.core.models.path.{And, Or, PathMethodRoles, PathRule}
 import com.fullfacing.keycloak4s.auth.core.validation.TokenValidator
-import com.fullfacing.keycloak4s.core.models.KeycloakConfig
+import com.fullfacing.keycloak4s.core.models.ConfigWithoutAuth
 import com.fullfacing.keycloak4s.core.models.enums.Methods
 
 object AuthTestData {
@@ -12,8 +12,7 @@ object AuthTestData {
   val port    = 8080
   val realm   = "test"
 
-  val authConfig     = KeycloakConfig.Secret("", "", "")
-  val keycloakConfig = KeycloakConfig(scheme, host, port, realm, authConfig)
+  val keycloakConfig = ConfigWithoutAuth(scheme, host, port, realm)
 
   implicit val validator: TokenValidator = TokenValidator.Static(TestData.jwkSet, keycloakConfig)
   val validatorUri = s"$scheme://$host:$port/auth/realms/$realm"

--- a/keycloak4s-playground/src/test/scala/utils/IntegrationSpec.scala
+++ b/keycloak4s-playground/src/test/scala/utils/IntegrationSpec.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import com.fullfacing.backend.AkkaMonixHttpBackend
 import com.fullfacing.keycloak4s.admin.monix.client.{Keycloak, KeycloakClient}
 import com.fullfacing.keycloak4s.admin.monix.services.{ClientScopes, _}
-import com.fullfacing.keycloak4s.core.models.KeycloakConfig
+import com.fullfacing.keycloak4s.core.models.{ConfigWithAuth, KeycloakConfig}
 import com.softwaremill.sttp.SttpBackend
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -19,7 +19,7 @@ class IntegrationSpec extends AsyncFlatSpec with Matchers with Inspectors {
 
   /* Keycloak Server Configuration **/
   val authConfig      = KeycloakConfig.Secret("master", "admin-cli", ServerInitializer.clientSecret)
-  val keycloakConfig  = KeycloakConfig("http", "127.0.0.1", 8080, "master", authConfig)
+  val keycloakConfig  = ConfigWithAuth("http", "127.0.0.1", 8080, "master", authConfig)
 
   /* Keycloak Client Implicits **/
   implicit val context: Scheduler = monix.execution.Scheduler.global


### PR DESCRIPTION
Replaced the code for attemptBuild, which could fail in certain environments, with a safer equivalent.

Determined to be necessary after the old code caused a service to enter a CrashLoopBackOff on our Kubernetes environment.

Update: Also transformed KeycloakConfig into a trait, with ConfigWithAuth and ConfigWithoutAuth as subtypes.