### PR TITLE
TokenValidator ISS fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] - 2019-09-05
+## [1.2.1] - 2019-09-10
 ### Fixed
 - Fixed a bug in TokenValidator resulting from the fact that Keycloak's internal URL builder drops common ports from the ISS.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2019-09-05
+### Fixed
+- Fixed a bug in TokenValidator resulting from the fact that Keycloak's internal URL builder drops common ports from the ISS.
+
 ## [1.2.0] - 2019-09-05
 ### Added
 - ConfigWithoutAuth; a version of KeycloakConfig that does not contain admin authentication details.

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import xerial.sbt.Sonatype.GitHubHosting
 
 lazy val global = {
   Seq(
-    version       := "1.2.0",
+    version       := "1.2.1",
     scalaVersion  := "2.12.8",
     organization  := "com.fullfacing",
     scalacOptions ++= scalacOpts,

--- a/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/validation/TokenValidator.scala
+++ b/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/validation/TokenValidator.scala
@@ -43,7 +43,14 @@ abstract class TokenValidator(val keycloakConfig: KeycloakConfig)(implicit ec: E
    */
   private def validateClaims(token: SignedJWT, now: Date): Either[KeycloakException, Unit] = {
     val claims  = token.getJWTClaimsSet
-    val uri     = s"${config.scheme}://${config.host}:${config.port}/auth/realms/${config.realm}"
+
+    /* Keycloak's internal URL builder drops common ports from the issuer. **/
+    /* TODO Determine all of the common ports Keycloak drops. **/
+    val uri = if (config.port == 80 || config.port == 443) {
+      s"${config.scheme}://${config.host}/auth/realms/${config.realm}"
+    } else {
+      s"${config.scheme}://${config.host}:${config.port}/auth/realms/${config.realm}"
+    }
 
     val validationResults = List(
       validateExp(claims, now),


### PR DESCRIPTION
Fixed a bug in TokenValidator resulting from the fact that Keycloak's internal URL builder drops common ports from the ISS.