### PR TITLE
make it possible to get an access token

### DIFF
--- a/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/TokenManager.scala
+++ b/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/TokenManager.scala
@@ -90,7 +90,7 @@ abstract class TokenManager[F[_] : Concurrent, -S](config: ConfigWithAuth)(impli
     *
     * @return
     */
-  private def issueAccessToken()(implicit cId: UUID): F[Either[KeycloakSttpException, Token]] = {
+  def issueAccessToken()(implicit cId: UUID): F[Either[KeycloakSttpException, Token]] = {
     val requestInfo = buildRequestInfo(tokenEndpoint.path, "POST", password)
 
     val sendF = Concurrent[F].unit.flatMap { _ =>


### PR DESCRIPTION
in order to write an integration test for our own routes and send requests to them, we need to have an accessToken that we can use with any tool to send authenticated requests

To make that possible the method must be available to be used.