### PR TITLE
User defined keycloak base path segments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ jobs:
         environment:
           KEYCLOAK_USER: "admin"
           KEYCLOAK_PASSWORD: "admin"
+    environment:
+      - _JAVA_OPTIONS: -XX:MaxMetaspaceSize=1536m
     steps:
       - checkout
       - run:

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val global = {
       case _                       => scalac213Opts
     }),
 
-    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full),
+    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.1" cross CrossVersion.full),
 
     credentials += Credentials("GnuPG Key ID", "gpg", "419C90FB607D11B0A7FE51CFDAF842ABC601C14F", "ignored"),
 
@@ -113,8 +113,8 @@ lazy val global = {
 // ---------------------------------- //
 //          Library Versions          //
 // ---------------------------------- //
-val akkaHttpVersion       = "10.2.0"
-val akkaStreamsVersion    = "2.6.8"
+val akkaHttpVersion       = "10.2.1"
+val akkaStreamsVersion    = "2.6.10"
 val catsEffectVersion     = "2.2.0"
 val catsCoreVersion       = "2.2.0"
 val enumeratumVersion     = "1.6.0"
@@ -122,8 +122,8 @@ val json4sVersion         = "3.6.10"
 val logbackVersion        = "1.2.3"
 val monixVersion          = "3.3.0"
 val monixBioVersion       = "1.1.0"
-val nimbusVersion         = "9.0"
-val scalaTestVersion      = "3.2.0"
+val nimbusVersion         = "9.1.2"
+val scalaTestVersion      = "3.2.3"
 val sttpVersion           = "2.2.9"
 
 // -------------------------------------- //

--- a/keycloak4s-admin-monix-bio/src/main/scala/com/fullfacing/keycloak4s/admin/monix/bio/client/KeycloakClient.scala
+++ b/keycloak4s-admin-monix-bio/src/main/scala/com/fullfacing/keycloak4s/admin/monix/bio/client/KeycloakClient.scala
@@ -30,7 +30,7 @@ class KeycloakClient[-S](config: ConfigWithAuth)(implicit client: SttpBackend[IO
     userInfo       = None,
     host           = config.host,
     port           = Some(config.port),
-    path           = Seq("auth", "admin", "realms") ++ path,
+    path           = config.basePath ++ Seq("admin", "realms") ++ path,
     querySegments  = query,
     fragment       = None
   )

--- a/keycloak4s-admin-monix-bio/src/main/scala/com/fullfacing/keycloak4s/admin/monix/bio/client/TokenManager.scala
+++ b/keycloak4s-admin-monix-bio/src/main/scala/com/fullfacing/keycloak4s/admin/monix/bio/client/TokenManager.scala
@@ -40,9 +40,8 @@ abstract class TokenManager[-S](config: ConfigWithAuth)(implicit client: SttpBac
     )
   }
 
-
   private val tokenEndpoint =
-    uri"${config.scheme}://${config.host}:${config.port}/auth/realms/${config.authn.realm}/protocol/openid-connect/token"
+    uri"${config.buildBaseUri}/realms/${config.authn.realm}/protocol/openid-connect/token"
 
   private val password = config.authn match {
     case KeycloakConfig.Password(_, clientId, username, pass) =>

--- a/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/KeycloakClient.scala
+++ b/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/KeycloakClient.scala
@@ -34,7 +34,7 @@ class KeycloakClient[F[+_] : Concurrent, -S](config: ConfigWithAuth)(implicit cl
     userInfo       = None,
     host           = config.host,
     port           = Some(config.port),
-    path           = Seq("auth", "admin", "realms") ++ path,
+    path           = config.basePath ++ Seq("admin", "realms") ++ path,
     querySegments  = query,
     fragment       = None
   )

--- a/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/TokenManager.scala
+++ b/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/TokenManager.scala
@@ -50,7 +50,7 @@ abstract class TokenManager[F[_] : Concurrent, -S](config: ConfigWithAuth)(impli
   }
 
   private val tokenEndpoint =
-    uri"${config.scheme}://${config.host}:${config.port}/auth/realms/${config.authn.realm}/protocol/openid-connect/token"
+    uri"${config.buildBaseUri}/realms/${config.authn.realm}/protocol/openid-connect/token"
 
   private val password = config.authn match {
     case KeycloakConfig.Password(_, clientId, username, pass) =>

--- a/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/validation/TokenValidator.scala
+++ b/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/validation/TokenValidator.scala
@@ -47,9 +47,9 @@ abstract class TokenValidator(val keycloakConfig: KeycloakConfig)(implicit ec: E
     /* Keycloak's internal URL builder drops common ports from the issuer. **/
     /* TODO Determine all of the common ports Keycloak drops. **/
     val uri = if (config.port == 80 || config.port == 443) {
-      s"${config.scheme}://${config.host}/auth/realms/${config.realm}"
+      s"${config.scheme}://${config.host}${if (config.basePath.nonEmpty) s"/${config.basePath.mkString("/")}" else ""}/realms/${config.realm}"
     } else {
-      s"${config.scheme}://${config.host}:${config.port}/auth/realms/${config.realm}"
+      s"${config.buildBaseUri}/realms/${config.realm}"
     }
 
     val validationResults = List(

--- a/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/validation/cache/JwksDynamicCache.scala
+++ b/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/validation/cache/JwksDynamicCache.scala
@@ -15,7 +15,7 @@ import com.nimbusds.jose.jwk.JWKSet
 trait JwksDynamicCache extends JwksCache {
 
   /* The URL to retrieve the Keycloak server's JWKS. **/
-  private val url = new URL(s"${config.scheme}://${config.host}:${config.port}/auth/realms/${config.realm}/protocol/openid-connect/certs")
+  private val url = new URL(s"${config.buildBaseUri}/realms/${config.realm}/protocol/openid-connect/certs")
 
   /* The cached response received from the Keycloak JWK set endpoint. **/
   protected val ref: AtomicReference[Either[KeycloakException, JWKSet]] = new AtomicReference[Either[KeycloakException, JWKSet]]()

--- a/keycloak4s-core/src/main/scala/com/fullfacing/keycloak4s/core/models/KeycloakConfig.scala
+++ b/keycloak4s-core/src/main/scala/com/fullfacing/keycloak4s/core/models/KeycloakConfig.scala
@@ -5,18 +5,23 @@ sealed trait KeycloakConfig {
   val host: String
   val port: Int
   val realm: String
+  val basePath: List[String]
+
+  def buildBaseUri: String = s"$scheme://$host:$port" + (if (basePath.nonEmpty) s"/${basePath.mkString("/")}" else "")
 }
 
 final case class ConfigWithAuth(scheme: String,
                                 host: String,
                                 port: Int,
                                 realm: String,
-                                authn: KeycloakConfig.Auth) extends KeycloakConfig
+                                authn: KeycloakConfig.Auth,
+                                basePath: List[String] = List("auth")) extends KeycloakConfig
 
 final case class ConfigWithoutAuth(scheme: String,
                                    host: String,
                                    port: Int,
-                                   realm: String) extends KeycloakConfig
+                                   realm: String,
+                                   basePath: List[String] = List("auth")) extends KeycloakConfig
 
 object KeycloakConfig {
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.3


### PR DESCRIPTION
Added handling for custom keycloak base paths in order to cater for use cases as detailed in #269 

`basePath` field added to `KeycloakConfig` and accordingly updated all cases of the Keycloak server URI being built