### PR TITLE
migrate non-monix modules to cats-effect 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ project/plugins/project/
 project/project/
 keycloak4s-admin/src/main/java/
 keycloak4s-admin/src/main/scala-2.11/
+
+# vscode
+.bloop
+.bsp
+.metals
+.vscode

--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ lazy val global = {
 // ---------------------------------- //
 val akkaHttpVersion       = "10.2.4"
 val akkaStreamsVersion    = "2.6.15"
-val catsEffectVersion     = "2.5.1"
+val catsEffectVersion     = "3.2.9"
 val catsCoreVersion       = "2.6.1"
 val enumeratumVersion     = "1.5.15"
 val json4sVersion         = "3.6.11"
@@ -206,20 +206,20 @@ lazy val `keycloak4s-admin` = (project in file("./keycloak4s-admin"))
 // ---------------------------------------------------- //
 // Project and configuration for keycloak4s-admin-monix //
 // ---------------------------------------------------- //
-lazy val `keycloak4s-monix` = (project in file("./keycloak4s-admin-monix"))
-  .settings(global: _*)
-  .settings(libraryDependencies ++= monix)
-  .settings(name := "keycloak4s-admin-monix", publishArtifact := true)
-  .dependsOn(`keycloak4s-admin`)
+// lazy val `keycloak4s-monix` = (project in file("./keycloak4s-admin-monix"))
+//   .settings(global: _*)
+//   .settings(libraryDependencies ++= monix)
+//   .settings(name := "keycloak4s-admin-monix", publishArtifact := true)
+//   .dependsOn(`keycloak4s-admin`)
 
 // ---------------------------------------------------- //
 // Project and configuration for keycloak4s-admin-monix //
 // ---------------------------------------------------- //
-lazy val `keycloak4s-monix-bio` = (project in file("./keycloak4s-admin-monix-bio"))
-  .settings(global: _*)
-  .settings(libraryDependencies ++= `monix-bio` ++ sttp)
-  .settings(name := "keycloak4s-admin-monix-bio", publishArtifact := true)
-  .dependsOn(`keycloak4s-core`)
+// lazy val `keycloak4s-monix-bio` = (project in file("./keycloak4s-admin-monix-bio"))
+//   .settings(global: _*)
+//   .settings(libraryDependencies ++= `monix-bio` ++ sttp)
+//   .settings(name := "keycloak4s-admin-monix-bio", publishArtifact := true)
+//   .dependsOn(`keycloak4s-core`)
 
 // ------------------------------------------------------- //
 // Project and configuration for keycloak4s-auth-core //
@@ -249,19 +249,19 @@ lazy val `keycloak4s-authz` = (project in file("./keycloak4s-authz-client"))
 // --------------------------------------------------- //
 // Project and configuration for keycloak4s-playground //
 // --------------------------------------------------- //
-lazy val `keycloak4s-playground` = (project in file("./keycloak4s-playground"))
-  .settings(scalaVersion  := "2.13.6")
-  .settings(publish / skip := true)
-  .settings(libraryDependencies ++= sttpAkkaMonix ++ scalaTest ++ akkaTestKit)
-  .settings(coverageEnabled := false)
-  .settings(Test / parallelExecution := false)
-  .settings(scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, n)) if n <= 12 => scalac212Opts
-    case _                       => scalac213Opts
-  }))
-  .settings(addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"))
-  .settings(name := "keycloak4s-playground", publishArtifact := false)
-  .dependsOn(`keycloak4s-admin`, `keycloak4s-monix`, `keycloak4s-akka-http`)
+// lazy val `keycloak4s-playground` = (project in file("./keycloak4s-playground"))
+//   .settings(scalaVersion  := "2.13.6")
+//   .settings(publish / skip := true)
+//   .settings(libraryDependencies ++= sttpAkkaMonix ++ scalaTest ++ akkaTestKit)
+//   .settings(coverageEnabled := false)
+//   .settings(Test / parallelExecution := false)
+//   .settings(scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+//     case Some((2, n)) if n <= 12 => scalac212Opts
+//     case _                       => scalac213Opts
+//   }))
+//   .settings(addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"))
+//   .settings(name := "keycloak4s-playground", publishArtifact := false)
+//   .dependsOn(`keycloak4s-admin`, `keycloak4s-monix`, `keycloak4s-akka-http`)
 
 // ---------------------------------------------- //
 // Project and configuration for the root project //
@@ -273,10 +273,10 @@ lazy val root = (project in file("."))
   .aggregate(
     `keycloak4s-core`,
     `keycloak4s-admin`,
-    `keycloak4s-monix`,
-    `keycloak4s-monix-bio`,
+    // `keycloak4s-monix`,
+    // `keycloak4s-monix-bio`,
     `keycloak4s-auth-core`,
     `keycloak4s-akka-http`,
-    `keycloak4s-authz`,
-    `keycloak4s-playground`
+    `keycloak4s-authz`
+    // `keycloak4s-playground`
   )

--- a/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/TokenManager.scala
+++ b/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/client/TokenManager.scala
@@ -171,8 +171,8 @@ abstract class TokenManager[F[_] : Concurrent](config: ConfigWithAuth)(implicit 
     }
   }.leftMap(_.getMessage)
 
-  private def getToken: F[Option[Token]] = Concurrent[F].delay(Option(ref.get))
-  private def setToken(token: Token): F[Unit] = Concurrent[F].delay(ref.set(token))
+  private def getToken: F[Option[Token]] = Concurrent[F].pure(Option(ref.get))
+  private def setToken(token: Token): F[Unit] = Concurrent[F].pure(ref.set(token))
 
   /**
     * Inspect the status of the token, reissuing a new access token using the password

--- a/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/services/package.scala
+++ b/keycloak4s-admin/src/main/scala/com/fullfacing/keycloak4s.admin/services/package.scala
@@ -34,11 +34,11 @@ package object services {
   }
 
   /** Creates a sequence of sttp KeyValues representing query parameters. */
-  def createQuery(queries: (String, Option[Any])*): ImmutableSeq[KeyValue] = ImmutableSeq {
+  def createQuery(queries: (String, Option[Any])*): ImmutableSeq[KeyValue] = ImmutableSeq.apply(
     queries.flatMap { case (key, value) =>
       value.map(v => KeyValue(key, v.toString))
     }: _*
-  }
+  )
 
   /** Creates a Multipart from a file. */
   def createMultipart(file: File): Part[BasicRequestBody] = {

--- a/keycloak4s-auth/akka-http/src/main/scala/com/fullfacing/keycloak4s/auth/akka/http/directives/magnets/SecurityMagnet.scala
+++ b/keycloak4s-auth/akka-http/src/main/scala/com/fullfacing/keycloak4s/auth/akka/http/directives/magnets/SecurityMagnet.scala
@@ -10,6 +10,7 @@ import com.fullfacing.keycloak4s.auth.core.authorization.PathAuthorization
 import com.fullfacing.keycloak4s.auth.core.authorization.PathAuthorization.AuthRequest
 import com.fullfacing.keycloak4s.auth.core.models.AuthPayload
 import com.fullfacing.keycloak4s.auth.core.validation.TokenValidator
+import cats.effect.unsafe.IORuntime
 
 trait SecurityMagnet {
   def apply(): Directive1[AuthPayload]
@@ -18,17 +19,17 @@ trait SecurityMagnet {
 object SecurityMagnet extends AuthDirectives with ValidationDirectives {
 
   /* Authorizes a request with a correlation ID passed through. **/
-  implicit def run(parameters: (PathAuthorization, UUID))(implicit tokenValidator: TokenValidator): SecurityMagnet = { () =>
+  implicit def run(parameters: (PathAuthorization, UUID))(implicit tokenValidator: TokenValidator, ioRuntime: IORuntime): SecurityMagnet = { () =>
     val (securityConfig, cId) = parameters
     authorize(securityConfig, cId)
   }
 
   /* Authorizes a request and generates a new correlation ID. **/
-  implicit def run(securityConfig: PathAuthorization)(implicit tokenValidator: TokenValidator): SecurityMagnet = { () =>
+  implicit def run(securityConfig: PathAuthorization)(implicit tokenValidator: TokenValidator, ioRuntime: IORuntime): SecurityMagnet = { () =>
     authorize(securityConfig, UUID.randomUUID())
   }
 
-  private def authorize(securityConfig: PathAuthorization, correlationId: => UUID)(implicit tokenValidator: TokenValidator): Directive1[AuthPayload] =
+  private def authorize(securityConfig: PathAuthorization, correlationId: => UUID)(implicit tokenValidator: TokenValidator, ioRuntime: IORuntime): Directive1[AuthPayload] =
     validateToken(correlationId).tflatMap { case (cId, authPayload) =>
       if (securityConfig.policyDisabled()) {
         provide(authPayload)

--- a/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/validation/TokenValidator.scala
+++ b/keycloak4s-auth/core/src/main/scala/com/fullfacing/keycloak4s/auth/core/validation/TokenValidator.scala
@@ -3,7 +3,7 @@ package com.fullfacing.keycloak4s.auth.core.validation
 import java.util.{Date, UUID}
 
 import cats.data.EitherT
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import cats.implicits._
 import com.fullfacing.keycloak4s.auth.core.Logging
 import com.fullfacing.keycloak4s.auth.core.Logging.logValidationEx
@@ -129,7 +129,7 @@ abstract class TokenValidator(val keycloakConfig: KeycloakConfig)(implicit ec: E
    * Parses and validates an access and ID token in parallel.
    */
   def parProcess(rawAccessToken: String, rawIdToken: String)(implicit cId: UUID): IO[Either[KeycloakException, AuthPayload]] = {
-    implicit val context: ContextShift[IO] = IO.contextShift(ec)
+    // implicit val context: ContextShift[IO] = IO.contextShift(ec)
     Logging.tokenValidating(cId)
 
     val now = new Date()


### PR DESCRIPTION
I migrated the core modules to cats-effect 3, looks like it is working. 
Skipped the monix-related modules but perhaps you find this PR a good start to continue the migration on.
